### PR TITLE
Bugfix: _append_ to title bar string now, instead of overwriting it

### DIFF
--- a/Unity-Powershell/Private/Update-TitleBarForUnityConnection.ps1
+++ b/Unity-Powershell/Private/Update-TitleBarForUnityConnection.ps1
@@ -4,7 +4,7 @@
 function Update-TitleBarForUnityConnection {
 	$strOrigWindowTitle = $host.ui.RawUI.WindowTitle
 	## the window titlebar text without the "connected to.." Unity info
-	$strWinTitleWithoutOldXmsConnInfo = $strOrigWindowTitle -replace "(; )?Connected to( \d+)? Unity.+", ""
+	$strWinTitleWithoutOldUnityConnInfo = $strOrigWindowTitle -replace "(; )?Connected to( \d+)? Unity.+", ""
 	## the number of Unity servers to which still connected
 	$intNumConnectedUnityServers = ($Global:DefaultUnitySession | Measure-Object).Count
 	$strNewWindowTitle = "{0}{1}{2}" -f $strWinTitleWithoutOldUnityConnInfo, $(if ((-not [System.String]::IsNullOrEmpty($strWinTitleWithoutOldUnityConnInfo)) -and ($intNumConnectedUnityServers -gt 0)) {"; "}), $(


### PR DESCRIPTION
Explained the situation in [this comment](https://github.com/equelin/Unity-Powershell/issues/19#issuecomment-286094551) on enhancement request #19.  Basically:  function for updating PS titlebar was overwriting titlebar info with Unity connection details, instead of appending (append is preferred, so as to keep other info that might already be in titlebar).

Fixed here (was an errant variable name).