### PR TITLE
Use basic parsing for Invoke-WebRequest.

### DIFF
--- a/Unity-Powershell/Private/Send-UnityRequest.ps1
+++ b/Unity-Powershell/Private/Send-UnityRequest.ps1
@@ -17,7 +17,7 @@ function Send-UnityRequest {
   If (($Method -eq 'GET') -or ($type -eq 'DELETE')) {
     Try
     {
-      $data = Invoke-WebRequest -Uri $URI -ContentType "application/json" -Websession $Session.Websession -Headers $session.headers -Method $Method
+      $data = Invoke-WebRequest -Uri $URI -ContentType "application/json" -Websession $Session.Websession -Headers $session.headers -Method $Method -UseBasicParsing
       return $data
     }
     Catch
@@ -30,7 +30,7 @@ function Send-UnityRequest {
     Try
     {
       $json = $body | ConvertTo-Json -Depth 10
-      $data = Invoke-WebRequest -Uri $URI -ContentType "application/json" -Body $json -Websession $Session.Websession -Headers $session.headers -Method $Method -TimeoutSec 6000
+      $data = Invoke-WebRequest -Uri $URI -ContentType "application/json" -Body $json -Websession $Session.Websession -Headers $session.headers -Method $Method -TimeoutSec 6000 -UseBasicParsing
       return $data
     }
     Catch
@@ -44,9 +44,9 @@ function Send-UnityRequest {
     {
       If ($body) {
         $json = $body | ConvertTo-Json -Depth 10
-        $data = Invoke-WebRequest -Uri $URI -ContentType "application/json" -Body $json -Websession $Session.Websession -Headers $session.headers -Method $Method
+        $data = Invoke-WebRequest -Uri $URI -ContentType "application/json" -Body $json -Websession $Session.Websession -Headers $session.headers -Method $Method -UseBasicParsing
       } else {
-        $data = Invoke-WebRequest -Uri $URI -ContentType "application/json" -Websession $Session.Websession -Headers $session.headers -Method $Method
+        $data = Invoke-WebRequest -Uri $URI -ContentType "application/json" -Websession $Session.Websession -Headers $session.headers -Method $Method -UseBasicParsing
       }
       return $data
     }

--- a/Unity-Powershell/Private/Test-UnityConnection.ps1
+++ b/Unity-Powershell/Private/Test-UnityConnection.ps1
@@ -18,7 +18,7 @@ Function Test-UnityConnection {
       Write-Verbose "URI: $URI"
 
       Try {
-        $request = Invoke-WebRequest -Uri $URI -ContentType "application/json" -Websession $sess.Websession -Headers $sess.headers -Method 'GET'
+        $request = Invoke-WebRequest -Uri $URI -ContentType "application/json" -Websession $sess.Websession -Headers $sess.headers -Method 'GET' -UseBasicParsing
       }
 
       Catch {

--- a/Unity-Powershell/Public/Disconnect-Unity.ps1
+++ b/Unity-Powershell/Public/Disconnect-Unity.ps1
@@ -55,7 +55,7 @@ Function Disconnect-Unity {
         if ($pscmdlet.ShouldProcess($sess.Server,"Disconnecting from Unity Array")) {
 
           #Sending request
-          $request = Invoke-WebRequest -Uri $URI -ContentType "application/json" -Websession $sess.Websession -Headers $sess.headers -Method POST
+          $request = Invoke-WebRequest -Uri $URI -ContentType "application/json" -Websession $sess.Websession -Headers $sess.headers -Method POST -UseBasicParsing
 
           If ($request.StatusCode -eq 200) {
             Write-Verbose "Delete session from DefaultUnitySession"

--- a/Unity-Powershell/Unity-Powershell.psm1
+++ b/Unity-Powershell/Unity-Powershell.psm1
@@ -82,7 +82,7 @@ Class UnitySession {
     $URI = 'https://'+$This.Server+'/api/types/system/instances'
 
     Try {
-        Invoke-WebRequest -Uri $URI -ContentType "application/json" -Websession $this.Websession -Headers $this.Headers -Method 'GET'
+        Invoke-WebRequest -Uri $URI -ContentType "application/json" -Websession $this.Websession -Headers $this.Headers -Method 'GET' -UseBasicParsing
     }
     Catch {
         $this.IsConnected = $false
@@ -113,6 +113,7 @@ Class UnitySession {
         Websession = $this.Websession
         Headers = $this.headers
         TimeoutSec = 6000
+        UseBasicParsing = $True
       }
 
       Write-Debug -Message "Request Parameters: $($Parameters | Out-String)"
@@ -139,6 +140,7 @@ Class UnitySession {
         TimeoutSec = 6000
         OutFile = $OutFile
         PassThru = $True
+        UseBasicParsing = $True
       }
 
       Write-Debug -Message "Request Parameters: $($Parameters | Out-String)"


### PR DESCRIPTION
This removes the dependency on the IE engine and first time run config of IE when the Invoke-WebRequest cmdlet is called. Without this I was getting failures in the "TestConnection" function with the message:

> The response content cannot be parsed because the Internet Explorer engine is not available, or Internet Explorer's first-launch configuration is not complete. Specify the UseBasicParsing parameter and try again.

Was deceiving because it worked fine on my normal machine, but got this error when attempting to run on a more restricted system as a scheduled task with a service account. 