### PR TITLE
Fixed issue #85

### DIFF
--- a/Unity-Powershell/Private/Update-TitleBarForUnityConnection.ps1
+++ b/Unity-Powershell/Private/Update-TitleBarForUnityConnection.ps1
@@ -14,5 +14,6 @@ function Update-TitleBarForUnityConnection {
 		} ## end if
 		#else {"Not Connected to Unity"}
 	) ## end -f call
-	$host.ui.RawUI.WindowTitle = $strNewWindowTitle
+	if ($host.ui.RawUI.WindowSize -ne $null) {$host.ui.RawUI.WindowTitle = $strNewWindowTitle}
+	#else {"Running non-interactive"}
 } ## end fn


### PR DESCRIPTION
This way we check whether or not Powershell is running interactive before updating the window titlebar. Hope this helps.